### PR TITLE
Added Caching & Time Stamps

### DIFF
--- a/src/app/Http/Controllers/HomeController.php
+++ b/src/app/Http/Controllers/HomeController.php
@@ -4,22 +4,28 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 
 class HomeController extends Controller
 {
     public function index(){
-        $authtoken = config('github.token');
-        if($authtoken == "public"){
-            $headers = [
-                'Accept'=>"application/vnd.github.v3+json"
-            ];
-        }else{
-            $headers = [
-                'Authorization'=>"token ".config('github.token'),
-                'Accept'=>"application/vnd.github.v3+json"
-            ];
+        if(!Storage::exists('/github/recent_commits.json') or time() - Storage::lastModified('/github/recent_commits.json') > 300){
+            $authtoken = config('github.token');
+            if($authtoken == "public"){
+                $headers = [
+                    'Accept'=>"application/vnd.github.v3+json"
+                ];
+            }else{
+                $headers = [
+                    'Authorization'=>"token ".config('github.token'),
+                    'Accept'=>"application/vnd.github.v3+json"
+                ];
+            }
+            $commits = Http::withHeaders($headers)->get('https://api.github.com/repos/DriedSponge/cs-club-website/commits?per_page=5');
+            Storage::put('/github/recent_commits.json',$commits);
         }
-        $commits = Http::withHeaders($headers)->get('https://api.github.com/repos/DriedSponge/cs-club-website/commits?per_page=5');
-        return view('pages.home')->with("commits",$commits->json());
+        $commits = json_decode(Storage::get('/github/recent_commits.json'),true);
+        $lastupdated = Storage::lastModified('/github/recent_commits.json');
+        return view('pages.home',['commits'=>$commits,'lastupdated'=>$lastupdated]);
     }
 }

--- a/src/resources/views/pages/home.blade.php
+++ b/src/resources/views/pages/home.blade.php
@@ -50,7 +50,7 @@ so now we want to specify what goes in that yield for this page.
         <div class="card shadow border-0 p-3">
             <div class="card-body">
                 <h2>Recent Commits</h2>
-                <br>
+                <h6 class="text-muted fst-italic mb-4">Updated: {{\Carbon\Carbon::parse($lastupdated)->diffForHumans()}}</p></h6>
                 @foreach($commits as $commit)
                     @if($commit['author'] == null)
                         @continue
@@ -62,7 +62,7 @@ so now we want to specify what goes in that yield for this page.
                                     <img data-src="{{$commit['author']['avatar_url']}}" class="lozad image-fluid rounded-circle" width="64" height="64">
                                 </div>
                                 <div class="col-lg-11 col-md-6">
-                                    <p class="card-text"><strong><a href="{{$commit['author']['html_url']}}" target="_blank">{{$commit['author']['login']}}</a> - {{$commit['commit']['message']}}</strong></p>
+                                    <p class="card-text"><strong><a href="{{$commit['author']['html_url']}}" target="_blank">{{$commit['author']['login']}}</a> - {{$commit['commit']['message']}}</strong> <span class="text-muted fst-italic">{{\Carbon\Carbon::parse($commit['commit']['committer']['date'])->diffForHumans()}}</span></p>
                                     <p class="card-text ">
                                         <a href="{{$commit['html_url']}}" target="_blank"><span class="badge  bg-primary">{{$commit['sha']}}</span></a>
                                         <a href="https://github.com/DriedSponge/cs-club-website" target="_blank"><span class="badge bg-success"><i class="fas fa-code-branch"></i> master</span></a>

--- a/src/resources/views/pages/home.blade.php
+++ b/src/resources/views/pages/home.blade.php
@@ -62,7 +62,7 @@ so now we want to specify what goes in that yield for this page.
                                     <img data-src="{{$commit['author']['avatar_url']}}" class="lozad image-fluid rounded-circle" width="64" height="64">
                                 </div>
                                 <div class="col-lg-11 col-md-6">
-                                    <p class="card-text"><strong><a href="{{$commit['author']['html_url']}}" target="_blank">{{$commit['author']['login']}}</a> - {{$commit['commit']['message']}}</strong> <span class="text-muted fst-italic">{{\Carbon\Carbon::parse($commit['commit']['committer']['date'])->diffForHumans()}}</span></p>
+                                    <p class="card-text"><strong><a href="{{$commit['author']['html_url']}}" target="_blank">{{$commit['author']['login']}}</a> - {{$commit['commit']['message']}}</strong> <span data-toggle="tooltip" data-placement="top" title="{{\Carbon\Carbon::parse($commit['commit']['committer']['date'])->setTimezone("America/Los_Angeles")->toDayDateTimeString()}}" class="text-muted fst-italic">{{\Carbon\Carbon::parse($commit['commit']['committer']['date'])->diffForHumans()}}</span></p>
                                     <p class="card-text ">
                                         <a href="{{$commit['html_url']}}" target="_blank"><span class="badge  bg-primary">{{$commit['sha']}}</span></a>
                                         <a href="https://github.com/DriedSponge/cs-club-website" target="_blank"><span class="badge bg-success"><i class="fas fa-code-branch"></i> master</span></a>
@@ -78,5 +78,9 @@ so now we want to specify what goes in that yield for this page.
     <script>
         const observer = lozad();
         observer.observe();
+        var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-toggle="tooltip"]'))
+        var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+            return new bootstrap.Tooltip(tooltipTriggerEl)
+        })
     </script>
 @endsection


### PR DESCRIPTION
Github api request for commits are now locally cached on the server, so we won't get rate limited. This will also make the home page load faster. I also added timestamps on the commits just as extra detail.